### PR TITLE
feat: add task flow with modern dashboard UI

### DIFF
--- a/src/components/dashboard/dashboard-client.tsx
+++ b/src/components/dashboard/dashboard-client.tsx
@@ -9,6 +9,8 @@ import { ChallengeHistory } from '@/components/dashboard/challenge-history'
 import { DailyCheckIn } from '@/components/dashboard/daily-checkin'
 import { useChallengeStore, useCurrentChallenge, useChallenges, useChallengeLoading, useChallengeError } from '@/lib/stores/challenge-store'
 import Link from 'next/link'
+import { TaskForm } from '@/components/tasks/task-form'
+import { TaskList } from '@/components/tasks/task-list'
 
 interface DashboardClientProps {
   user: any
@@ -136,6 +138,10 @@ export function DashboardClient({ user, profile }: DashboardClientProps) {
             completedAt: c.updated_at,
             earnings: c.status === 'completed' ? c.stake_amount : 0
           }))} />
+
+          {/* Tasks */}
+          <TaskForm />
+          <TaskList />
         </div>
 
         {/* Sidebar */}

--- a/src/components/tasks/task-form.tsx
+++ b/src/components/tasks/task-form.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { useTaskStore } from '@/lib/stores/task-store'
+
+export function TaskForm() {
+  const addTask = useTaskStore((state) => state.addTask)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!title.trim()) return
+    addTask({ title: title.trim(), description: description.trim() || undefined })
+    setTitle('')
+    setDescription('')
+  }
+
+  return (
+    <Card className="mb-6">
+      <CardHeader>
+        <CardTitle className="text-lg">Create Task</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <Input
+            placeholder="Task title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+          />
+          <textarea
+            className="flex min-h-[80px] w-full rounded-lg border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <Button type="submit" disabled={!title.trim()}>Add Task</Button>
+        </form>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/tasks/task-list.tsx
+++ b/src/components/tasks/task-list.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { useTasks, useTaskStore } from '@/lib/stores/task-store'
+
+export function TaskList() {
+  const tasks = useTasks()
+  const toggleTask = useTaskStore((state) => state.toggleTask)
+
+  if (tasks.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-6 text-center text-muted-foreground">
+          No tasks yet. Add one above to get started.
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-lg">Your Tasks</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {tasks.map((task) => (
+          <div
+            key={task.id}
+            className="flex items-center justify-between rounded-lg p-2 hover:bg-muted"
+          >
+            <div className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-primary"
+                checked={task.status === 'completed'}
+                onChange={() => toggleTask(task.id)}
+              />
+              <div>
+                <p
+                  className={`font-medium ${
+                    task.status === 'completed'
+                      ? 'line-through text-muted-foreground'
+                      : ''
+                  }`}
+                >
+                  {task.title}
+                </p>
+                {task.description && (
+                  <p className="text-sm text-muted-foreground">
+                    {task.description}
+                  </p>
+                )}
+              </div>
+            </div>
+            <span className="text-xs text-muted-foreground">
+              {new Date(task.createdAt).toLocaleDateString()}
+            </span>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/lib/stores/task-store.ts
+++ b/src/lib/stores/task-store.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand'
+
+export interface Task {
+  id: string
+  title: string
+  description?: string
+  createdAt: string
+  status: 'pending' | 'completed'
+}
+
+interface TaskState {
+  tasks: Task[]
+}
+
+interface TaskActions {
+  addTask: (task: { title: string; description?: string }) => void
+  toggleTask: (id: string) => void
+}
+
+type TaskStore = TaskState & TaskActions
+
+export const useTaskStore = create<TaskStore>((set) => ({
+  tasks: [],
+  addTask: ({ title, description }) =>
+    set((state) => ({
+      tasks: [
+        ...state.tasks,
+        {
+          id: crypto.randomUUID(),
+          title,
+          description,
+          createdAt: new Date().toISOString(),
+          status: 'pending',
+        },
+      ],
+    })),
+  toggleTask: (id) =>
+    set((state) => ({
+      tasks: state.tasks.map((task) =>
+        task.id === id
+          ? {
+              ...task,
+              status: task.status === 'completed' ? 'pending' : 'completed',
+            }
+          : task
+      ),
+    })),
+}))
+
+export const useTasks = () => useTaskStore((state) => state.tasks)


### PR DESCRIPTION
## Summary
- add Zustand task store for local tasks
- create modern TaskForm and TaskList components
- surface task creation and listing on dashboard

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: react/no-unescaped-entities and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689778dc3a04832ea1e19320cfcf47c2